### PR TITLE
Pin claude code version, optimize dockerfile to reduce size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Version control
+.git
+.gitignore
+
+# Documentation
+*.md
+
+# Example files
+example/
+
+# Images
+*.jpg
+
+# Docker files
+compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,11 @@
-# Use Ubuntu LTS as base image for better compatibility
-FROM ubuntu:24.04
+# Use official Node.js Alpine image
+FROM node:22-alpine
 
-# Set environment variables
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    wget \
-    git \
-    build-essential \
-    ca-certificates \
-    gnupg \
-    lsb-release \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js 22 (latest LTS)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs
-
-# Verify Node.js installation
-RUN node --version && npm --version
+# Install git (required by Claude Code)
+RUN apk add --no-cache git
 
 # Install Claude Code globally
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@~2.0.0
 
 # Create directories with proper ownership
 RUN mkdir -p /claude /workspace && \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A Docker container with Claude Code pre-installed and ready to use. This contain
 
 Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com/r/nezhar/claude-container)
 
+## Compatibility Matrix
+
+| Container Version | Claude Code Version |
+|-------------------|---------------------|
+| 1.0.x             | 1.0.x               |
+| 1.1.x             | 2.0.x               |
+
 ## Quick Start
 
 ### Using Docker Compose


### PR DESCRIPTION
This pull request updates the Docker container for Claude Code to use a lighter and more streamlined base image, improves dependency management, and enhances documentation and development workflow. The most important changes are grouped below:

**Container Base Image and Dependencies:**

* Switched the base image in `Dockerfile` from `ubuntu:24.04` to the official `node:22-alpine` image, simplifying the environment and reducing image size.
* Removed manual installation of Node.js and system dependencies; now relies on the Node.js Alpine image and installs only `git` via `apk`.

**Claude Code Version Management:**

* Explicitly installs `@anthropic-ai/claude-code` version `~2.0.0` globally, ensuring compatibility and stability.

**Documentation and Workflow Improvements:**

* Added a compatibility matrix to `README.md` to clarify which container versions correspond to which Claude Code versions.
* Introduced a `.dockerignore` file to exclude version control files, documentation, example files, images, and Docker Compose files from the build context, improving build efficiency and security.