### PR TITLE
Add bash script for local integration of container and proxy for data logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ example/workspace/
 example/claude-config/
 example/proxy-data/
 proxy-data/
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Claude Container
 
-A Docker container with Claude Code pre-installed and ready to use. This container includes all necessary dependencies and provides an easy way to run Claude Code in an isolated environment.
+A Docker container with Claude Code pre-installed and ready to use.
+
+This container includes all necessary dependencies and provides an easy way to run Claude Code in an isolated environment.
+
+An optional proxy can be enabled to track all the requests made by Claude Code in a local SQLite database.
 
 ## Docker Hub
 
-Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com/r/nezhar/claude-container)
+Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com/r/nezhar/claude-container) and [nezhar/claude-proxy](https://hub.docker.com/r/nezhar/claude-proxy)
 
 ## Compatibility Matrix
 
@@ -18,10 +22,38 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 
 ## Quick Start
 
+### Using the Helper Script (Recommended)
+
+The easiest way to run Claude Container is using the provided bash script. Download and install it with:
+
+```bash
+# Download the script directly from GitHub
+curl -o ~/.local/bin/claude-container https://raw.githubusercontent.com/nezhar/claude-container/main/bin/claude-container
+
+# Make it executable
+chmod +x ~/.local/bin/claude-container
+
+# Run Claude Code
+claude-container
+```
+
+Make sure `~/.local/bin` is in your PATH. Alternatively, install to `/usr/local/bin`:
+
+```bash
+# Download and install system-wide (requires sudo)
+sudo curl -o /usr/local/bin/claude-container https://raw.githubusercontent.com/nezhar/claude-container/main/bin/claude-container
+sudo chmod +x /usr/local/bin/claude-container
+```
+
+The script handles all Docker configuration automatically and supports additional features like API logging. Run with `--help` to see all available options:
+
+```bash
+claude-container --help
+```
+
 ### Using Docker Compose
 
-Create a `compose.yml` file as provided in the example folder.
-
+Create a `compose.yml` file as provided in the example folder. 
 ```bash
 docker compose run claude-code claude
 ```
@@ -39,7 +71,7 @@ This will store the credentials in `$HOME/.config/claude-container` and will be 
 
 ## How does the authentication work
 
-When you run Claude Code for the first time, you'll go through the following authentication steps:
+When you run the container for the first time, you'll go through the following authentication steps:
 
 1. **Choose Color Schema**: Select your preferred terminal color scheme
 
@@ -59,7 +91,7 @@ When you run Claude Code for the first time, you'll go through the following aut
 
 ## Integration with Existing Projects
 
-To integrate Claude Code into an existing Docker Compose project, create a `compose.override.yml` file:
+To integrate Claude Container into an existing Docker Compose project, create a `compose.override.yml` file:
 
 ```yaml
 services:
@@ -92,28 +124,9 @@ This repository includes an optional logging proxy that captures all Anthropic A
 - Analyzing request/response patterns
 - Building custom analytics tools
 
-### Quick Start with Docker Compose
+### Running with Docker
 
-**Run Claude Code directly:**
-```bash
-cd example
-docker compose run claude-code claude
-```
-
-**Run with logging proxy:**
-```bash
-cd example
-# Start the proxy container
-docker compose up -d proxy
-# Run Claude Code (configured to use the proxy)
-docker compose run claude-code claude
-```
-
-The proxy will automatically intercept all API requests and log them to `./proxy-data/requests.db`.
-
-### Running with Docker (without Compose)
-
-**Run Claude Code directly:**
+**Run Claude Container directly:**
 ```bash
 docker run --rm -it \
   -v "$(pwd):/workspace" \
@@ -147,15 +160,6 @@ docker run --rm -it \
 docker stop claude-proxy
 docker rm claude-proxy
 docker network rm claude-network
-```
-
-### Viewing Logs
-
-```bash
-# Using sqlite3
-sqlite3 proxy-data/requests.db "SELECT timestamp, method, path, response_status, duration_ms FROM request_logs ORDER BY timestamp DESC LIMIT 10;"
-
-# Or use any SQLite browser tool
 ```
 
 ### Proxy Configuration

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# Claude Container Launcher
+# A convenient script to run Claude Code in a Docker container
+#
+# Usage:
+#   claude-container [options] [command]
+#
+# Options:
+#   --workspace, -w <path>  Set workspace directory (default: current directory)
+#   --config, -c <path>     Set config directory (default: $HOME/.config/claude-container)
+#   --proxy                 Enable API logging proxy
+#   --proxy-data <path>     Set proxy data directory (default: ./proxy-data)
+#   --proxy-stop            Stop and cleanup proxy container
+#   --proxy-logs            Show proxy logs
+#   --help, -h              Show this help message
+#
+# Examples:
+#   claude-container                    # Run in current directory
+#   claude-container --proxy            # Run with API logging proxy
+#   claude-container --proxy-stop       # Stop proxy and cleanup
+#   claude-container -w /path/to/code   # Run with custom workspace
+#
+
+set -e
+
+# Version information
+# Container and proxy are always released with the same version
+VERSION="1.2.0"
+
+# Default values
+WORKSPACE_DIR="$(pwd)"
+CONFIG_BASE_DIR="$HOME/.config/claude-container"
+CONFIG_DIR="$HOME/.config/claude-container/config"
+PROXY_DATA_DIR="$HOME/.config/claude-container/proxy-data"
+IMAGE="nezhar/claude-container:${VERSION}"
+PROXY_IMAGE="nezhar/claude-proxy:${VERSION}"
+COMMAND="claude"
+USE_PROXY=false
+NETWORK_NAME="claude-network"
+PROXY_CONTAINER_NAME="claude-proxy"
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to display help
+show_help() {
+    cat << EOF
+Claude Container Launcher
+
+A convenient script to run Claude Code in a Docker container with optional API logging.
+
+USAGE:
+    claude-container [OPTIONS] [COMMAND]
+
+OPTIONS:
+    -w, --workspace <path>      Set workspace directory (default: current directory)
+    -c, --config <path>         Set config directory (default: \$HOME/.config/claude-container/config)
+    -h, --help                  Show this help message
+    --pull                      Pull latest images before running
+    --version                   Show container version information
+
+PROXY OPTIONS:
+    --proxy                     Enable API logging proxy
+    -p, --proxy-data <path>     Set proxy data directory (default: \$HOME/.config/claude-container/proxy-data)
+    --proxy-stop                Stop and cleanup proxy container
+    --proxy-logs                Show proxy container logs
+
+EXAMPLES:
+    claude-container                        # Run in current directory
+    claude-container --proxy                # Run with API logging enabled
+    claude-container --proxy-stop           # Stop the proxy container
+    claude-container --proxy-logs           # View proxy logs
+    claude-container -w /path/to/project    # Run with custom workspace
+    claude-container --pull                 # Pull latest images and run
+    claude-container ls -la                 # Run custom command in container
+
+ENVIRONMENT VARIABLES:
+    CLAUDE_WORKSPACE      Override default workspace directory
+    CLAUDE_CONFIG         Override default config directory
+    CLAUDE_PROXY_DATA     Override default proxy data directory
+    CLAUDE_IMAGE          Override default Docker image
+    CLAUDE_PROXY_IMAGE    Override default proxy image
+
+PROXY DATABASE:
+    When using --proxy, all API requests are logged to: <proxy-data>/requests.db
+
+    View recent requests:
+        sqlite3 proxy-data/requests.db "SELECT timestamp, method, path, response_status FROM request_logs ORDER BY timestamp DESC LIMIT 10;"
+
+FIRST TIME SETUP:
+    On first run, you'll be prompted to authenticate with Claude.
+    Your credentials will be stored in the config directory for future use.
+
+EOF
+}
+
+# Function to stop proxy
+stop_proxy() {
+    if docker ps -a --format '{{.Names}}' | grep -q "^${PROXY_CONTAINER_NAME}$"; then
+        echo -e "${YELLOW}Stopping proxy container...${NC}"
+        docker stop "$PROXY_CONTAINER_NAME" 2>/dev/null || true
+        docker rm "$PROXY_CONTAINER_NAME" 2>/dev/null || true
+    fi
+
+    if docker network ls --format '{{.Name}}' | grep -q "^${NETWORK_NAME}$"; then
+        # Check if network has any containers
+        if [ -z "$(docker network inspect "$NETWORK_NAME" -f '{{range .Containers}}{{.Name}}{{end}}' 2>/dev/null)" ]; then
+            echo -e "${YELLOW}Removing network...${NC}"
+            docker network rm "$NETWORK_NAME" 2>/dev/null || true
+        fi
+    fi
+}
+
+# Function to start proxy
+start_proxy() {
+    # Create network if it doesn't exist
+    if ! docker network ls --format '{{.Name}}' | grep -q "^${NETWORK_NAME}$"; then
+        echo -e "${GREEN}Creating Docker network...${NC}"
+        docker network create "$NETWORK_NAME"
+    fi
+
+    # Check if proxy is already running
+    if docker ps --format '{{.Names}}' | grep -q "^${PROXY_CONTAINER_NAME}$"; then
+        echo -e "${BLUE}Proxy is already running${NC}"
+        return 0
+    fi
+
+    # Remove stopped proxy container if exists
+    if docker ps -a --format '{{.Names}}' | grep -q "^${PROXY_CONTAINER_NAME}$"; then
+        docker rm "$PROXY_CONTAINER_NAME" 2>/dev/null || true
+    fi
+
+    # Create proxy data directory if it doesn't exist
+    if [ ! -d "$PROXY_DATA_DIR" ]; then
+        echo -e "${YELLOW}Creating proxy data directory: $PROXY_DATA_DIR${NC}"
+        mkdir -p "$PROXY_DATA_DIR"
+    fi
+
+    # Start proxy container
+    echo -e "${GREEN}Starting proxy container...${NC}"
+    docker run -d \
+        --name "$PROXY_CONTAINER_NAME" \
+        --network "$NETWORK_NAME" \
+        -v "$PROXY_DATA_DIR:/data" \
+        -p 8080:8080 \
+        "$PROXY_IMAGE"
+
+    echo -e "${GREEN}Proxy started successfully${NC}"
+    echo -e "Proxy logs: ${YELLOW}$PROXY_DATA_DIR/requests.db${NC}"
+}
+
+# Function to cleanup on exit
+cleanup() {
+    local exit_code=$?
+    if [ $exit_code -ne 0 ] && [ "$USE_PROXY" = true ]; then
+        echo -e "\n${YELLOW}Error occurred. Cleaning up...${NC}"
+        stop_proxy
+    fi
+}
+
+# Parse command line arguments
+STOP_PROXY=false
+SHOW_LOGS=false
+PULL_IMAGES=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -w|--workspace)
+            WORKSPACE_DIR="$2"
+            shift 2
+            ;;
+        -c|--config)
+            CONFIG_DIR="$2"
+            shift 2
+            ;;
+        --proxy)
+            USE_PROXY=true
+            shift
+            ;;
+        -p|--proxy-data)
+            PROXY_DATA_DIR="$2"
+            shift 2
+            ;;
+        --proxy-stop)
+            STOP_PROXY=true
+            shift
+            ;;
+        --proxy-logs)
+            SHOW_LOGS=true
+            shift
+            ;;
+        --pull)
+            PULL_IMAGES=true
+            shift
+            ;;
+        --version)
+            echo -e "${GREEN}Running version check...${NC}"
+            docker run --rm "$IMAGE" claude --version
+            exit 0
+            ;;
+        *)
+            # Treat remaining arguments as command to run
+            COMMAND="$@"
+            break
+            ;;
+    esac
+done
+
+# Override with environment variables if set
+WORKSPACE_DIR="${CLAUDE_WORKSPACE:-$WORKSPACE_DIR}"
+CONFIG_DIR="${CLAUDE_CONFIG:-$CONFIG_DIR}"
+PROXY_DATA_DIR="${CLAUDE_PROXY_DATA:-$PROXY_DATA_DIR}"
+IMAGE="${CLAUDE_IMAGE:-$IMAGE}"
+PROXY_IMAGE="${CLAUDE_PROXY_IMAGE:-$PROXY_IMAGE}"
+
+# Handle proxy-stop command
+if [ "$STOP_PROXY" = true ]; then
+    stop_proxy
+    echo -e "${GREEN}Proxy stopped and cleaned up${NC}"
+    exit 0
+fi
+
+# Handle proxy-logs command
+if [ "$SHOW_LOGS" = true ]; then
+    if docker ps --format '{{.Names}}' | grep -q "^${PROXY_CONTAINER_NAME}$"; then
+        docker logs -f "$PROXY_CONTAINER_NAME"
+    else
+        echo -e "${RED}Error: Proxy container is not running${NC}"
+        exit 1
+    fi
+    exit 0
+fi
+
+# Pull images if requested
+if [ "$PULL_IMAGES" = true ]; then
+    echo -e "${GREEN}Pulling latest images...${NC}"
+    docker pull "$IMAGE"
+    if [ "$USE_PROXY" = true ]; then
+        docker pull "$PROXY_IMAGE"
+    fi
+fi
+
+# Validate workspace directory
+if [ ! -d "$WORKSPACE_DIR" ]; then
+    echo -e "${RED}Error: Workspace directory does not exist: $WORKSPACE_DIR${NC}"
+    exit 1
+fi
+
+# Create config directory if it doesn't exist
+if [ ! -d "$CONFIG_DIR" ]; then
+    echo -e "${YELLOW}Creating config directory: $CONFIG_DIR${NC}"
+    mkdir -p "$CONFIG_DIR"
+fi
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${RED}Error: Docker is not running or not accessible${NC}"
+    echo "Please start Docker and try again."
+    exit 1
+fi
+
+# Convert paths to absolute paths
+WORKSPACE_DIR="$(cd "$WORKSPACE_DIR" && pwd)"
+CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)" 2>/dev/null || CONFIG_DIR="$(mkdir -p "$CONFIG_DIR" && cd "$CONFIG_DIR" && pwd)"
+
+# Handle proxy mode
+if [ "$USE_PROXY" = true ]; then
+    # Convert proxy data dir to absolute path
+    PROXY_DATA_DIR="$(cd "$(dirname "$PROXY_DATA_DIR")" 2>/dev/null && pwd)/$(basename "$PROXY_DATA_DIR")" || PROXY_DATA_DIR="$(pwd)/$(basename "$PROXY_DATA_DIR")"
+    mkdir -p "$PROXY_DATA_DIR"
+    PROXY_DATA_DIR="$(cd "$PROXY_DATA_DIR" && pwd)"
+
+    # Set trap for cleanup
+    trap cleanup EXIT INT TERM
+
+    # Start proxy
+    start_proxy
+
+    echo -e "\n${GREEN}Starting Claude Container with API logging...${NC}"
+    echo -e "Version:    ${YELLOW}$VERSION${NC}"
+    echo -e "Workspace:  ${YELLOW}$WORKSPACE_DIR${NC}"
+    echo -e "Config:     ${YELLOW}$CONFIG_DIR${NC}"
+    echo -e "Proxy logs: ${YELLOW}$PROXY_DATA_DIR/requests.db${NC}"
+    echo ""
+
+    # Run the container with proxy
+    docker run --rm -it \
+        --network "$NETWORK_NAME" \
+        -v "$WORKSPACE_DIR:/workspace" \
+        -v "$CONFIG_DIR:/claude" \
+        -e "CLAUDE_CONFIG_DIR=/claude" \
+        -e "ANTHROPIC_BASE_URL=http://$PROXY_CONTAINER_NAME:8080" \
+        "$IMAGE" \
+        $COMMAND
+
+    # Note: Proxy is intentionally left running for potential subsequent runs
+    echo -e "\n${BLUE}Proxy container is still running. Use '$0 --proxy-stop' to stop it.${NC}"
+else
+    # Run without proxy
+    echo -e "${GREEN}Starting Claude Container...${NC}"
+    echo -e "Version:   ${YELLOW}$VERSION${NC}"
+    echo -e "Workspace: ${YELLOW}$WORKSPACE_DIR${NC}"
+    echo -e "Config:    ${YELLOW}$CONFIG_DIR${NC}"
+    echo ""
+
+    # Run the container
+    docker run --rm -it \
+        -v "$WORKSPACE_DIR:/workspace" \
+        -v "$CONFIG_DIR:/claude" \
+        -e "CLAUDE_CONFIG_DIR=/claude" \
+        "$IMAGE" \
+        $COMMAND
+fi


### PR DESCRIPTION
This pull request updates the `README.md` to improve the onboarding experience for new users. The main change is the addition of a recommended helper script for running Claude Container, making setup easier and more accessible.

**Documentation improvements:**

* Added a new "Using the Helper Script (Recommended)" section to the quick start guide, including instructions for downloading, installing, and running the `claude-container` bash script. This simplifies the initial setup for users.
* Provided details on installing the script either for a single user or system-wide, and clarified the need for the installation directory to be in the user's PATH.
* Explained that the script automates Docker configuration and supports extra features like API logging, with a reference to `--help` for more options.