### PR TITLE
Bump to 1.3.2 version, uses claude code 2.0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.3.1 (Claude Code 2.0.17)
+**Latest Release:** 1.3.2 (Claude Code 2.0.29)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|
 | 1.0.x             | 1.0.x               |
 | 1.1.x             | 2.0.x               |
 | 1.2.x             | 2.0.x               |
-| 1.3.x             | 2.0.x              |
+| 1.3.x             | 2.0.x               |
 
 ## Quick Start
 

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.3.1"
+VERSION="1.3.2"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release of the project.

- Updated the "Latest Release" version from 1.3.1 (Claude Code 2.0.17) to 1.3.2 (Claude Code 2.0.29).