### PR TITLE
Use custom entrypoint to handle file permissions correctly inside workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.3.2 (Claude Code 2.0.29)
+**Latest Release:** 1.4.0 (Claude Code 2.0.32)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|
@@ -20,6 +20,7 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 | 1.1.x             | 2.0.x               |
 | 1.2.x             | 2.0.x               |
 | 1.3.x             | 2.0.x               |
+| 1.4.x             | 2.0.x               |
 
 ## Quick Start
 

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.3.2"
+VERSION="1.4.0"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"
@@ -453,6 +453,8 @@ if [ "$USE_PROXY" = true ]; then
         -v "$CONFIG_DIR:/claude" \
         -e "CLAUDE_CONFIG_DIR=/claude" \
         -e "ANTHROPIC_BASE_URL=http://$PROXY_CONTAINER_NAME:8080" \
+        -e "USER_UID=$(id -u)" \
+        -e "USER_GID=$(id -g)" \
         "$IMAGE" \
         $COMMAND
 
@@ -477,6 +479,8 @@ else
         -v "$WORKSPACE_DIR:/workspace" \
         -v "$CONFIG_DIR:/claude" \
         -e "CLAUDE_CONFIG_DIR=/claude" \
+        -e "USER_UID=$(id -u)" \
+        -e "USER_GID=$(id -g)" \
         "$IMAGE" \
         $COMMAND
 fi

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -1,17 +1,23 @@
 # Use official Node.js Alpine image
 FROM node:22-alpine
 
-# Install git (required by Claude Code)
-RUN apk add --no-cache git
+# Install git and su-exec (required by Claude Code and entrypoint)
+RUN apk add --no-cache git su-exec
 
 # Install Claude Code globally
 RUN npm install -g @anthropic-ai/claude-code@~2.0.0
 
-# Create directories with proper ownership
-RUN mkdir -p /claude /workspace && \
-    chown -R 1000:1000 /claude /workspace
+# Create directories
+RUN mkdir -p /claude /workspace
 
-# Create workspace directory
+# Copy entrypoint script
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set working directory
 WORKDIR /workspace
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["sh", "-c", "echo 'Claude Code container is ready!'"]

--- a/claude-code/entrypoint.sh
+++ b/claude-code/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Entrypoint script for Claude Code container
+# Handles dynamic UID/GID mapping to match host user
+#
+
+set -e
+
+# Default to user 1000:1000 if not specified
+USER_UID=${USER_UID:-1000}
+USER_GID=${USER_GID:-1000}
+
+# If running as root (UID 0), stay as root
+if [ "$USER_UID" -eq 0 ]; then
+    exec "$@"
+fi
+
+# Create group if it doesn't exist
+# First check if GID is already in use
+if ! getent group "$USER_GID" >/dev/null 2>&1; then
+    addgroup -g "$USER_GID" claude 2>/dev/null || true
+else
+    # If GID exists but not with name 'claude', use existing group
+    EXISTING_GROUP=$(getent group "$USER_GID" | cut -d: -f1)
+    if [ -n "$EXISTING_GROUP" ] && [ "$EXISTING_GROUP" != "claude" ]; then
+        GROUP_NAME="$EXISTING_GROUP"
+    else
+        GROUP_NAME="claude"
+    fi
+fi
+
+# Default group name if not set
+GROUP_NAME=${GROUP_NAME:-claude}
+
+# Create user if it doesn't exist
+# First check if UID is already in use
+if ! getent passwd "$USER_UID" >/dev/null 2>&1; then
+    adduser -D -u "$USER_UID" -G "$GROUP_NAME" -h /home/claude -s /bin/sh claude 2>/dev/null || true
+    USER_NAME="claude"
+else
+    # If UID exists, use existing user
+    USER_NAME=$(getent passwd "$USER_UID" | cut -d: -f1)
+fi
+
+# Fix ownership of config directory (usually needs fixing on first run)
+if [ -d /claude ]; then
+    chown -R "$USER_UID:$USER_GID" /claude 2>/dev/null || true
+fi
+
+# Don't recursively chown workspace - files created by the container will automatically
+# have the correct ownership since we're running as USER_UID:USER_GID
+# Only ensure the directory itself is accessible
+if [ -d /workspace ]; then
+    chmod 755 /workspace 2>/dev/null || true
+fi
+
+# Switch to the user and execute the command
+# Use the actual username to ensure proper environment setup
+exec su-exec "${USER_NAME}" "$@"


### PR DESCRIPTION
This pull request updates the container setup for the Claude Code environment to support dynamic user and group ID mapping, improving compatibility with host file permissions and security best practices. The main changes introduce an entrypoint script that handles user/group creation and privilege dropping, and modifies the Dockerfile to use this script as the container entrypoint.

Container entrypoint and user mapping improvements:

* Added a new `entrypoint.sh` script that dynamically creates or reuses users and groups based on `USER_UID` and `USER_GID` environment variables, ensuring files created inside the container have the correct ownership on the host. The script uses `su-exec` to drop privileges before running the main process.
* Modified the `Dockerfile` to install `su-exec`, copy and set up the new `entrypoint.sh` script, and set it as the container entrypoint. This replaces the previous static directory ownership setup and ensures the container can run as any user specified at runtime.