### PR TITLE
Bump to 1.4.2 version, extend reamde for update notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.1 (Claude Code 2.0.36)
+**Latest Release:** 1.4.2 (Claude Code 2.0.36)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|
@@ -67,6 +67,26 @@ source ~/.bashrc
 ```
 
 Once installed, you can use tab completion with `claude-container --<TAB>` to see all available options
+
+#### Updating to the Latest Version
+
+To update to the latest version, simply re-download the helper script and completions:
+
+```bash
+# Update helper script (user install)
+curl -o ~/.local/bin/claude-container https://raw.githubusercontent.com/nezhar/claude-container/main/bin/claude-container
+
+# Or for system-wide install
+sudo curl -o /usr/local/bin/claude-container https://raw.githubusercontent.com/nezhar/claude-container/main/bin/claude-container
+
+# Update completions (if installed)
+curl -o ~/.local/share/bash-completion/completions/claude-container https://raw.githubusercontent.com/nezhar/claude-container/main/completions/claude-container
+
+# Verify the new version
+claude-container --version
+```
+
+The helper script will automatically pull the latest Docker images when needed.
 
 ### Using Docker Compose
 

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.1"
+VERSION="1.4.2"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to reflect the latest release and adds instructions for updating the helper script and completions. The most important changes are grouped below:

Release information update:
* Updated the "Latest Release" version from 1.4.1 to 1.4.2 in the compatibility matrix to reflect the newest release.

Documentation improvements:
* Added a new section with step-by-step instructions for updating the `claude-container` helper script and bash completions, including commands for both user and system-wide installations.
* Clarified that the helper script will automatically pull the latest Docker images when needed.