### PR TITLE
Bump to 1.4.3 version, uses claude code 2.0.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.2 (Claude Code 2.0.36)
+**Latest Release:** 1.4.3 (Claude Code 2.0.42)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.2"
+VERSION="1.4.3"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release version of the project.

Documentation update:

* Updated the `README.md` file to show the new latest release version as 1.4.3 (Claude Code 2.0.42).