### PR TITLE
Set shell environment for claude code

### DIFF
--- a/claude-code/entrypoint.sh
+++ b/claude-code/entrypoint.sh
@@ -56,4 +56,6 @@ fi
 
 # Switch to the user and execute the command
 # Use the actual username to ensure proper environment setup
+# Set SHELL environment variable for Claude Code
+export SHELL=/bin/sh
 exec su-exec "${USER_NAME}" "$@"


### PR DESCRIPTION
This pull request makes a small change to the environment setup in the `claude-code/entrypoint.sh` script. The change sets the `SHELL` environment variable to `/bin/sh` before executing the command as the specified user.

* Environment setup: Added `export SHELL=/bin/sh` to ensure the correct shell is set for Claude Code.