### PR TITLE
Extend readme to include more details about the images and stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,44 @@ This container includes all necessary dependencies and provides an easy way to r
 
 An optional proxy can be enabled to track all the requests made by Claude Code in a local SQLite database.
 
-## Docker Hub
+## Available Images
 
-Images available on Docker Hub: [nezhar/claude-container](https://hub.docker.com/r/nezhar/claude-container) and [nezhar/claude-proxy](https://hub.docker.com/r/nezhar/claude-proxy)
+Three Docker images are available on Docker Hub, all released with matching version tags:
+
+| Image | Purpose | Base |
+|-------|---------|------|
+| [nezhar/claude-container](https://hub.docker.com/r/nezhar/claude-container) | Main container with Claude Code CLI pre-installed | Node.js 22 Alpine |
+| [nezhar/claude-proxy](https://hub.docker.com/r/nezhar/claude-proxy) | Optional HTTP proxy that logs all API requests to SQLite | Python 3.12 Alpine |
+| [nezhar/claude-datasette](https://hub.docker.com/r/nezhar/claude-datasette) | Optional web UI for visualizing and querying logged requests | Datasette + plugins |
+
+### Architecture Overview
+
+When using all three images together, the request flow looks like this:
+
+```
+┌─────────────────┐      ┌──────────────────┐      ┌─────────────────────┐
+│ claude-container│─────▶│  claude-proxy    │─────▶│  api.anthropic.com  │
+│  (Claude Code)  │      │   (HTTP Proxy)   │      │   (Anthropic API)   │
+└─────────────────┘      └────────┬─────────┘      └─────────────────────┘
+                                  │
+                                  ▼
+                         ┌─────────────────┐
+                         │  requests.db    │
+                         │   (SQLite)      │
+                         └────────┬────────┘
+                                  │
+                                  ▼
+                         ┌─────────────────┐
+                         │claude-datasette │
+                         │   (Web UI)      │
+                         └─────────────────┘
+                         http://localhost:8001
+```
+
+**Standalone Usage:**
+- Use **claude-container** alone for basic Claude Code functionality
+- Add **claude-proxy** when you need API request logging
+- Add **claude-datasette** when you want to visualize and analyze logs
 
 ## Compatibility Matrix
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to provide a clearer overview of the available Docker images and their purposes, as well as an architectural diagram showing how the images interact. The changes make it easier for users to understand the different components and how to use them together.

Docker image documentation improvements:

* Expanded the section on available Docker images to include a table describing each image's purpose and base, covering `nezhar/claude-container`, `nezhar/claude-proxy`, and `nezhar/claude-datasette`.
* Added an architecture diagram and explanation to illustrate how the three images work together, including request flow and logging.
* Provided guidance for standalone and combined usage scenarios for the images.