### PR TITLE
Bump to 1.4.5 version, uses claude code 2.0.50

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.4 (Claude Code 2.0.46)
+**Latest Release:** 1.4.5 (Claude Code 2.0.50)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.4"
+VERSION="1.4.5"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release version of the project.

Documentation update:

* Updated the `README.md` to show `1.4.5 (Claude Code 2.0.50)` as the latest release