### PR TITLE
Bump to 1.4.6 version, uses claude code 2.0.61

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.5 (Claude Code 2.0.50)
+**Latest Release:** 1.4.6 (Claude Code 2.0.61)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.5"
+VERSION="1.4.6"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"

--- a/claude-code/entrypoint.sh
+++ b/claude-code/entrypoint.sh
@@ -42,9 +42,13 @@ else
     USER_NAME=$(getent passwd "$USER_UID" | cut -d: -f1)
 fi
 
-# Fix ownership of config directory (usually needs fixing on first run)
+# Ensure config directory is accessible without modifying existing credential files
+# Only fix ownership of the directory itself, not its contents
 if [ -d /claude ]; then
-    chown -R "$USER_UID:$USER_GID" /claude 2>/dev/null || true
+    # Change ownership of the directory itself
+    chown "$USER_UID:$USER_GID" /claude 2>/dev/null || true
+    # Ensure it's writable
+    chmod 755 /claude 2>/dev/null || true
 fi
 
 # Don't recursively chown workspace - files created by the container will automatically


### PR DESCRIPTION
This pull request updates the release version and improves the handling of the config directory ownership in the entrypoint script. The most important changes are grouped below:

Release version update:

* Updated the documented latest release to version `1.4.6` (Claude Code 2.0.61) in `README.md` to reflect the newest container and Claude Code versions.

Container startup and permissions:

* Modified `claude-code/entrypoint.sh` to only change the ownership of the `/claude` config directory itself (not its contents), and ensured the directory is writable, preventing unintended modification of credential files.