### PR TITLE
Bump to 1.4.7 version, uses claude code 2.0.65

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.6 (Claude Code 2.0.61)
+**Latest Release:** 1.4.7 (Claude Code 2.0.65)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.6"
+VERSION="1.4.7"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release version.

* Documentation update: Changed the "Latest Release" in `README.md` from version 1.4.6 (Claude Code 2.0.61) to 1.4.7 (Claude Code 2.0.65).