### PR TITLE
Bump to 1.5.0 version, uses claude code 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.4.9 (Claude Code 2.0.76)
+**Latest Release:** 1.5.0 (Claude Code 2.1.2)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|
@@ -56,6 +56,7 @@ When using all three images together, the request flow looks like this:
 | 1.2.x             | 2.0.x               |
 | 1.3.x             | 2.0.x               |
 | 1.4.x             | 2.0.x               |
+| 1.5.x             | 2.1.x               |
 
 ## Quick Start
 

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.4.9"
+VERSION="1.5.0"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-alpine
 RUN apk add --no-cache git su-exec
 
 # Install Claude Code globally
-RUN npm install -g @anthropic-ai/claude-code@~2.0.0
+RUN npm install -g @anthropic-ai/claude-code@~2.1.0
 
 # Create directories
 RUN mkdir -p /claude /workspace


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release and compatibility information for the project.

Documentation updates:

* Updated the "Latest Release" version in the `README.md` from `1.4.9 (Claude Code 2.0.76)` to `1.5.0 (Claude Code 2.1.2)` to indicate the new release.
* Added a new row to the compatibility matrix in `README.md` showing support for container version `1.5.x` with Claude Code version `2.1.x`.