### PR TITLE
Add bash to claude code container

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -1,8 +1,8 @@
 # Use official Node.js Alpine image
 FROM node:22-alpine
 
-# Install git and su-exec (required by Claude Code and entrypoint)
-RUN apk add --no-cache git su-exec
+# Install git, su-exec, and bash (required by Claude Code and entrypoint)
+RUN apk add --no-cache git su-exec bash
 
 # Install Claude Code globally
 RUN npm install -g @anthropic-ai/claude-code@~2.1.0

--- a/claude-code/entrypoint.sh
+++ b/claude-code/entrypoint.sh
@@ -61,5 +61,5 @@ fi
 # Switch to the user and execute the command
 # Use the actual username to ensure proper environment setup
 # Set SHELL environment variable for Claude Code
-export SHELL=/bin/sh
+export SHELL=/bin/bash
 exec su-exec "${USER_NAME}" "$@"


### PR DESCRIPTION
This pull request updates the Docker setup for Claude Code to improve compatibility and environment consistency. The main changes involve switching the default shell to Bash and ensuring Bash is available in the container.

**Environment and Shell Updates:**

* Added installation of `bash` in the Dockerfile to ensure Bash is available for the entrypoint and Claude Code.
* Changed the default `SHELL` environment variable in `entrypoint.sh` from `/bin/sh` to `/bin/bash` to use Bash for the application runtime.