### PR TITLE
Bump to 1.5.2 version, uses claude code 2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.5.1 (Claude Code 2.1.3)
+**Latest Release:** 1.5.2 (Claude Code 2.1.5)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.5.1"
+VERSION="1.5.2"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release version of the project.

Documentation update:
  * Updated the `README.md` file to indicate the latest release is now version 1.5.2 (Claude Code 2.1.5), replacing the previous version 1.5.1 (Claude Code 2.1.3).