### PR TITLE
Bump to 1.5.3 version, uses claude code 2.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When using all three images together, the request flow looks like this:
 
 ## Compatibility Matrix
 
-**Latest Release:** 1.5.2 (Claude Code 2.1.5)
+**Latest Release:** 1.5.3 (Claude Code 2.1.12)
 
 | Container Version | Claude Code Version |
 |-------------------|---------------------|

--- a/bin/claude-container
+++ b/bin/claude-container
@@ -26,7 +26,7 @@ set -e
 
 # Version information
 # Container and proxy are always released with the same version
-VERSION="1.5.2"
+VERSION="1.5.3"
 
 # Default values
 WORKSPACE_DIR="$(pwd)"


### PR DESCRIPTION
This pull request updates the documentation to reflect the latest release version of the project.

- Documentation Update:
  * Updated the "Latest Release" version in `README.md` from 1.5.2 (Claude Code 2.1.5) to 1.5.3 (Claude Code 2.1.12), ensuring users see the most current release information.