### PR TITLE
feat: add linux/arm64 platform support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           context: claude-code
           push: true
           no-cache: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             nezhar/claude-container:${{ steps.version.outputs.version }}
             nezhar/claude-container:latest
@@ -50,7 +50,7 @@ jobs:
           context: claude-proxy
           push: true
           no-cache: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             nezhar/claude-proxy:${{ steps.version.outputs.version }}
             nezhar/claude-proxy:latest
@@ -61,7 +61,7 @@ jobs:
           context: claude-datasette
           push: true
           no-cache: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             nezhar/claude-datasette:${{ steps.version.outputs.version }}
             nezhar/claude-datasette:latest


### PR DESCRIPTION
## Summary
- Add `linux/arm64` to build platforms for all three images (claude-container, claude-proxy, claude-datasette)
- The Dockerfiles already use multi-arch base images (`node:22-alpine`, `python:3.12-alpine`) so no Dockerfile changes are needed
- This enables running on Apple Silicon (M1/M2/M3/M4) Macs without emulation

> [!Note]
> Responses generated with Claude

## Test plan
- [ ] Verify the multi-arch build completes successfully in CI
- [ ] Test pulling and running the arm64 image on an Apple Silicon Mac